### PR TITLE
use user hint, disable input while logging in

### DIFF
--- a/main.js
+++ b/main.js
@@ -11,6 +11,14 @@ window.authentication_complete = function() {
         $( 'body' ).fadeOut( 1000, () => {
             lightdm.login(lightdm.authentication_user, null);
         } );
+    } else {
+        getImg();
+        input.value = "";
+        input.placeholder = "user";
+        input.type = "text";
+        input.disabled = false;
+        input.focus();
+        input.select();
     }
 }
 
@@ -29,23 +37,21 @@ window.onload = function() {
     getImg();
     input.focus();
     input.select();
+    input.value = lightdm.select_user_hint;
+    if(input.value) {
+      authenticate(input.value);
+    }
 }
 
 function authenticate(input_text) {
-    if(!lightdm.in_authentication) {
+    if(!lightdm.in_authentication || !lightdm.authentication_user) {
         lightdm.authenticate(input_text);
         input.value = "";
         input.type = "password";
         input.placeholder = "password";
-    } else if(!lightdm.authentication_user) {
-        lightdm.respond(input_text);
-        input.value = "";
-        input.type = "password";
-        input.placeholder = "password";
+        input.disabled = false;
     } else {
+        input.disabled = true;
         lightdm.respond(input_text);
-        input.value = "";
-        input.type = "text";
-        input.placeholder = "user";
     }
 }


### PR DESCRIPTION
Great work on this theme, I love it. Here's a few tweaks I made.

Use the lightdm select_user_hint so that users don't need to provide a username when unlocking a locked session.

When logging in, disable the input box and keep in password mode until the authentication call returns. If it is successful, then change it to a user prompt.

Currently the input box changes to a user prompt immediately while the login is still processing. If you start typing during this time, then hit enter, you will be prompted for the username a second time.

Also this cycles the image on every failed login, which I think is a nice touch.